### PR TITLE
Feat: Block Dashboard에 Drag할 때 input 블록 값 반영

### DIFF
--- a/src/components/common/InputBlock.jsx
+++ b/src/components/common/InputBlock.jsx
@@ -1,15 +1,29 @@
+import { useState } from "react";
+
 import { InputBlockContainer } from "../../style/BlockStyle";
 
-const InputBlock = ({ parameter, saveBlockData }) => {
+const InputBlock = ({ parameter, saveBlockData, draggedValue }) => {
+  const [inputValue, setInputValue] = useState(draggedValue);
+
   const handleDragStart = () => {
     saveBlockData({
       type: "input",
       parameter: parameter,
+      value: inputValue,
     });
   };
+
+  const handleInputChange = (event) => {
+    setInputValue(event.target.value);
+  };
+
   return (
     <InputBlockContainer draggable="true" onDragStart={handleDragStart}>
-      <input placeholder={parameter} />
+      <input
+        placeholder={parameter}
+        onChange={handleInputChange}
+        value={inputValue}
+      />
     </InputBlockContainer>
   );
 };

--- a/src/components/common/LineBlock.jsx
+++ b/src/components/common/LineBlock.jsx
@@ -10,7 +10,13 @@ const LineBlock = ({ number, blocks }) => {
       {blocks.map((block) => {
         switch (block.type) {
           case "input":
-            return <InputBlock key={block.id} parameter={block.parameter} />;
+            return (
+              <InputBlock
+                key={block.id}
+                parameter={block.parameter}
+                draggedValue={block.value}
+              />
+            );
           case "method":
             return <MethodBlock key={block.id} method={block.method} />;
           default:


### PR DESCRIPTION
## 제목

Block Dashboard에 Drag할 때 input 블록 값 반영

## 내용

![image](https://github.com/user-attachments/assets/7986b0ba-ceb4-49e0-b367-d47036a73304)

Block Container에서 Block Dashboard로 Drag할 때 input 필드의 값이 반영되어 생성됩니다.

## 항목

- input 필드 값이 반영되어 생성
- 생성 후 반영된 값 수정 가능

## 특이 사항

- Block Container의 블록 값이 초기화되는 기능은 구현하지 못했습니다.

## 주의 사항

- [x] PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요

# PR 전 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다
- [x] base 브랜치명을 확인하였습니다
- [x] 코드 컨벤션을 모두 확인하였습니다
- [x] 셀프 리뷰를 진행하였습니다.
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!
