### PR TITLE
Feat: Block Dashboard에서 Del 또는 BackSpace키로 블록 삭제 기능 구현

### DIFF
--- a/src/components/BlockContainer.jsx
+++ b/src/components/BlockContainer.jsx
@@ -9,10 +9,7 @@ import {
 } from "../style/BlockContainerStyle";
 import { Header, Section, Content } from "../style/CommonStyle";
 
-const BlockContainer = ({
-  handleDragStart,
-  setSelectedBlockId = { setSelectedBlockId },
-}) => {
+const BlockContainer = ({ handleDragStart, setSelectedBlockId }) => {
   return (
     <Section>
       <Header>

--- a/src/components/BlockContainer.jsx
+++ b/src/components/BlockContainer.jsx
@@ -9,7 +9,10 @@ import {
 } from "../style/BlockContainerStyle";
 import { Header, Section, Content } from "../style/CommonStyle";
 
-const BlockContainer = ({ handleDragStart }) => {
+const BlockContainer = ({
+  handleDragStart,
+  setSelectedBlockId = { setSelectedBlockId },
+}) => {
   return (
     <Section>
       <Header>
@@ -21,20 +24,50 @@ const BlockContainer = ({ handleDragStart }) => {
             <InputBlock
               parameter="https://www.google.com"
               saveBlockData={handleDragStart}
+              setSelectedBlockId={setSelectedBlockId}
             />
-            <InputBlock parameter="url" saveBlockData={handleDragStart} />
-            <InputBlock parameter="selector" saveBlockData={handleDragStart} />
-            <InputBlock parameter="value" saveBlockData={handleDragStart} />
+            <InputBlock
+              parameter="url"
+              saveBlockData={handleDragStart}
+              setSelectedBlockId={setSelectedBlockId}
+            />
+            <InputBlock
+              parameter="selector"
+              saveBlockData={handleDragStart}
+              setSelectedBlockId={setSelectedBlockId}
+            />
+            <InputBlock
+              parameter="value"
+              saveBlockData={handleDragStart}
+              setSelectedBlockId={setSelectedBlockId}
+            />
           </InputBlockList>
           <MethodBlockList>
-            <MethodBlock method="이동합니다." saveBlockData={handleDragStart} />
-            <MethodBlock method="클릭합니다." saveBlockData={handleDragStart} />
-            <MethodBlock method="입력합니다." saveBlockData={handleDragStart} />
+            <MethodBlock
+              method="이동합니다."
+              saveBlockData={handleDragStart}
+              setSelectedBlockId={setSelectedBlockId}
+            />
+            <MethodBlock
+              method="클릭합니다."
+              saveBlockData={handleDragStart}
+              setSelectedBlockId={setSelectedBlockId}
+            />
+            <MethodBlock
+              method="입력합니다."
+              saveBlockData={handleDragStart}
+              setSelectedBlockId={setSelectedBlockId}
+            />
             <MethodBlock
               method="로그인합니다."
               saveBlockData={handleDragStart}
+              setSelectedBlockId={setSelectedBlockId}
             />
-            <MethodBlock method="오픈합니다." saveBlockData={handleDragStart} />
+            <MethodBlock
+              method="오픈합니다."
+              saveBlockData={handleDragStart}
+              setSelectedBlockId={setSelectedBlockId}
+            />
           </MethodBlockList>
         </BlockList>
         <TextBox title="Text Box" />

--- a/src/components/BlockDashboard.jsx
+++ b/src/components/BlockDashboard.jsx
@@ -20,6 +20,7 @@ const BlockDashboard = ({
   handleDrop,
   handleCreateLineBlock,
   handleLineBlockReorder,
+  setSelectedBlockId,
 }) => {
   const [draggedLineBlockIndex, setDraggedLineBlockIndex] = useState(null);
   const [isTextButtonDisabled, setIsTextButtonDisabled] = useState({
@@ -84,6 +85,7 @@ const BlockDashboard = ({
               }
               handleLineBlockDragOver={handleDragOver}
               handleLineBlockDrop={() => handleLineBlockDrop(lineBlockIndex)}
+              setSelectedBlockId={setSelectedBlockId}
             />
           ))}
         </LineBlockList>

--- a/src/components/common/InputBlock.jsx
+++ b/src/components/common/InputBlock.jsx
@@ -6,11 +6,13 @@ const InputBlock = ({ parameter, saveBlockData, draggedValue }) => {
   const [inputValue, setInputValue] = useState(draggedValue || "");
 
   const handleDragStart = () => {
-    saveBlockData({
+    const draggedBlock = {
       type: "input",
       parameter: parameter,
       value: inputValue,
-    });
+    };
+
+    saveBlockData(draggedBlock);
   };
 
   const handleInputChange = (event) => {

--- a/src/components/common/InputBlock.jsx
+++ b/src/components/common/InputBlock.jsx
@@ -2,7 +2,13 @@ import { useState } from "react";
 
 import { InputBlockContainer } from "../../style/BlockStyle";
 
-const InputBlock = ({ parameter, saveBlockData, draggedValue }) => {
+const InputBlock = ({
+  parameter,
+  saveBlockData,
+  draggedValue,
+  id,
+  setSelectedBlockId,
+}) => {
   const [inputValue, setInputValue] = useState(draggedValue || "");
 
   const handleDragStart = () => {
@@ -19,8 +25,17 @@ const InputBlock = ({ parameter, saveBlockData, draggedValue }) => {
     setInputValue(event.target.value);
   };
 
+  const handleClickBlock = () => {
+    const selectedBlockId = id;
+    setSelectedBlockId(selectedBlockId);
+  };
+
   return (
-    <InputBlockContainer draggable="true" onDragStart={handleDragStart}>
+    <InputBlockContainer
+      draggable="true"
+      onDragStart={handleDragStart}
+      onClick={handleClickBlock}
+    >
       <input
         placeholder={parameter}
         onChange={handleInputChange}

--- a/src/components/common/InputBlock.jsx
+++ b/src/components/common/InputBlock.jsx
@@ -6,7 +6,7 @@ const InputBlock = ({
   parameter,
   saveBlockData,
   draggedValue,
-  id,
+  inputBlockId,
   setSelectedBlockId,
 }) => {
   const [inputValue, setInputValue] = useState(draggedValue || "");
@@ -26,7 +26,7 @@ const InputBlock = ({
   };
 
   const handleClickBlock = () => {
-    const selectedBlockId = id;
+    const selectedBlockId = inputBlockId;
     setSelectedBlockId(selectedBlockId);
   };
 

--- a/src/components/common/LineBlock.jsx
+++ b/src/components/common/LineBlock.jsx
@@ -15,6 +15,7 @@ const LineBlock = ({
   handleLineBlockDragStart,
   handleLineBlockDragOver,
   handleLineBlockDrop,
+  setSelectedBlockId,
 }) => {
   const handleDragStart = (event) => {
     event.dataTransfer.setData("text/plain", "lineblock");
@@ -52,6 +53,8 @@ const LineBlock = ({
                   parameter={block.parameter}
                   saveBlockData={handleBlockDragStart}
                   draggedValue={block.value}
+                  id={block.id}
+                  setSelectedBlockId={setSelectedBlockId}
                 />
               );
             case "method":
@@ -60,6 +63,8 @@ const LineBlock = ({
                   key={block.id}
                   method={block.method}
                   saveBlockData={handleBlockDragStart}
+                  id={block.id}
+                  setSelectedBlockId={setSelectedBlockId}
                 />
               );
             default:

--- a/src/components/common/LineBlock.jsx
+++ b/src/components/common/LineBlock.jsx
@@ -10,8 +10,9 @@ import {
 const LineBlock = ({
   index,
   blocks,
-  handleLineBlockDragStart,
+  handleBlockDragStart,
   handleBlockDrop,
+  handleLineBlockDragStart,
   handleLineBlockDragOver,
   handleLineBlockDrop,
 }) => {
@@ -49,11 +50,18 @@ const LineBlock = ({
                 <InputBlock
                   key={block.id}
                   parameter={block.parameter}
+                  saveBlockData={handleBlockDragStart}
                   draggedValue={block.value}
                 />
               );
             case "method":
-              return <MethodBlock key={block.id} method={block.method} />;
+              return (
+                <MethodBlock
+                  key={block.id}
+                  method={block.method}
+                  saveBlockData={handleBlockDragStart}
+                />
+              );
             default:
               return null;
           }

--- a/src/components/common/LineBlock.jsx
+++ b/src/components/common/LineBlock.jsx
@@ -53,7 +53,7 @@ const LineBlock = ({
                   parameter={block.parameter}
                   saveBlockData={handleBlockDragStart}
                   draggedValue={block.value}
-                  id={block.id}
+                  inputBlockId={block.id}
                   setSelectedBlockId={setSelectedBlockId}
                 />
               );
@@ -63,7 +63,7 @@ const LineBlock = ({
                   key={block.id}
                   method={block.method}
                   saveBlockData={handleBlockDragStart}
-                  id={block.id}
+                  methodBlockId={block.id}
                   setSelectedBlockId={setSelectedBlockId}
                 />
               );

--- a/src/components/common/MethodBlock.jsx
+++ b/src/components/common/MethodBlock.jsx
@@ -1,6 +1,11 @@
 import { MethodBlockContainer } from "../../style/BlockStyle";
 
-const MethodBlock = ({ method, saveBlockData, id, setSelectedBlockId }) => {
+const MethodBlock = ({
+  method,
+  saveBlockData,
+  methodBlockId,
+  setSelectedBlockId,
+}) => {
   const handleDragStart = () => {
     const draggedBlock = {
       type: "method",
@@ -11,7 +16,7 @@ const MethodBlock = ({ method, saveBlockData, id, setSelectedBlockId }) => {
   };
 
   const handleClickBlock = () => {
-    const selectedBlockId = id;
+    const selectedBlockId = methodBlockId;
     setSelectedBlockId(selectedBlockId);
   };
 

--- a/src/components/common/MethodBlock.jsx
+++ b/src/components/common/MethodBlock.jsx
@@ -2,10 +2,12 @@ import { MethodBlockContainer } from "../../style/BlockStyle";
 
 const MethodBlock = ({ method, saveBlockData }) => {
   const handleDragStart = () => {
-    saveBlockData({
+    const draggedBlock = {
       type: "method",
       method: method,
-    });
+    };
+
+    saveBlockData(draggedBlock);
   };
   return (
     <MethodBlockContainer draggable="true" onDragStart={handleDragStart}>

--- a/src/components/common/MethodBlock.jsx
+++ b/src/components/common/MethodBlock.jsx
@@ -1,6 +1,6 @@
 import { MethodBlockContainer } from "../../style/BlockStyle";
 
-const MethodBlock = ({ method, saveBlockData }) => {
+const MethodBlock = ({ method, saveBlockData, id, setSelectedBlockId }) => {
   const handleDragStart = () => {
     const draggedBlock = {
       type: "method",
@@ -9,8 +9,18 @@ const MethodBlock = ({ method, saveBlockData }) => {
 
     saveBlockData(draggedBlock);
   };
+
+  const handleClickBlock = () => {
+    const selectedBlockId = id;
+    setSelectedBlockId(selectedBlockId);
+  };
+
   return (
-    <MethodBlockContainer draggable="true" onDragStart={handleDragStart}>
+    <MethodBlockContainer
+      draggable="true"
+      onDragStart={handleDragStart}
+      onClick={handleClickBlock}
+    >
       <p className="method-block-name">{method}</p>
     </MethodBlockContainer>
   );

--- a/src/pages/Main.jsx
+++ b/src/pages/Main.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useCallback } from "react";
 
 import BlockContainer from "../components/BlockContainer";
 import BlockDashboard from "../components/BlockDashboard";
@@ -72,22 +72,17 @@ const Main = () => {
     }
   }, [selectedBlockId]);
 
-  useEffect(() => {
-    const handleKeyDown = (event) => {
+  const handleKeyDown = useCallback(
+    (event) => {
       if (event.key === "Delete" || event.key === "Backspace") {
         handleDeleteBlock();
       }
-    };
-
-    window.addEventListener("keydown", handleKeyDown);
-
-    return () => {
-      window.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [handleDeleteBlock]);
+    },
+    [handleDeleteBlock],
+  );
 
   return (
-    <main>
+    <main onKeyDown={handleKeyDown} tabIndex={-1}>
       <Modal title="title" content="content" />
       <BlockContainer
         handleDragStart={handleDragStart}

--- a/src/pages/Main.jsx
+++ b/src/pages/Main.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect, useCallback } from "react";
 
 import BlockContainer from "../components/BlockContainer";
 import BlockDashboard from "../components/BlockDashboard";
@@ -13,6 +13,7 @@ const Main = () => {
     },
   ]);
   const [draggedBlock, setDraggedBlock] = useState(null);
+  const [selectedBlockId, setSelectedBlockId] = useState(null);
 
   const handleDragStart = (block) => {
     setDraggedBlock(block);
@@ -57,16 +58,49 @@ const Main = () => {
     });
   };
 
+  const handleDeleteBlock = useCallback(() => {
+    if (selectedBlockId !== null) {
+      setLineBlocks((prevLineBlocks) =>
+        prevLineBlocks.map((lineBlock) => ({
+          ...lineBlock,
+          blocks: lineBlock.blocks.filter(
+            (block) => block.id !== selectedBlockId,
+          ),
+        })),
+      );
+      setSelectedBlockId(null);
+    }
+  }, [selectedBlockId]);
+
+  useEffect(() => {
+    const handleKeyDown = (event) => {
+      if (event.key === "Delete" || event.key === "Backspace") {
+        handleDeleteBlock();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [handleDeleteBlock]);
+
   return (
     <main>
       <Modal title="title" content="content" />
-      <BlockContainer handleDragStart={handleDragStart} />
+      <BlockContainer
+        handleDragStart={handleDragStart}
+        setSelectedBlockId={selectedBlockId}
+      />
       <BlockDashboard
         lineBlocks={lineBlocks}
         handleDragStart={handleDragStart}
         handleDrop={handleDrop}
         handleCreateLineBlock={handleCreateLineBlock}
         handleLineBlockReorder={handleLineBlockReorder}
+        setSelectedBlockId={setSelectedBlockId}
+        handleDeleteBlock={handleDeleteBlock}
       />
       <TestCodeDashboard text="Loading" />
     </main>

--- a/src/pages/Main.jsx
+++ b/src/pages/Main.jsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState } from "react";
 
 import BlockContainer from "../components/BlockContainer";
 import BlockDashboard from "../components/BlockDashboard";
@@ -58,7 +58,7 @@ const Main = () => {
     });
   };
 
-  const handleDeleteBlock = useCallback(() => {
+  const handleDeleteBlock = () => {
     if (selectedBlockId !== null) {
       setLineBlocks((prevLineBlocks) =>
         prevLineBlocks.map((lineBlock) => ({
@@ -70,23 +70,20 @@ const Main = () => {
       );
       setSelectedBlockId(null);
     }
-  }, [selectedBlockId]);
+  };
 
-  const handleKeyDown = useCallback(
-    (event) => {
-      if (event.key === "Delete" || event.key === "Backspace") {
-        handleDeleteBlock();
-      }
-    },
-    [handleDeleteBlock],
-  );
+  const handleKeyDown = (event) => {
+    if (event.key === "Delete" || event.key === "Backspace") {
+      handleDeleteBlock();
+    }
+  };
 
   return (
-    <main onKeyDown={handleKeyDown} tabIndex={-1}>
+    <main onKeyDown={handleKeyDown} tabIndex="0">
       <Modal title="title" content="content" />
       <BlockContainer
         handleDragStart={handleDragStart}
-        setSelectedBlockId={selectedBlockId}
+        setSelectedBlockId={setSelectedBlockId}
       />
       <BlockDashboard
         lineBlocks={lineBlocks}


### PR DESCRIPTION
## 제목

Block Dashboard에서 블록 삭제 기능 구현
## 내용

Block Dashboard에서 블록을 클릭하고 키보드 del 키나 BackSpace 키를 누르면 Dashboard에서 삭제됩니다.
![화면-기록-2024-08-16-오후-9 44 29](https://github.com/user-attachments/assets/99a098c9-572e-4f12-8d29-f2d1bf0be2e3)



## 항목

- 클릭한 블록의 id를 상태로 관리
- handleClickBlock 함수 구현
- useEffect를 사용해 del, BackSpace 키보드 이벤트 감지 후 삭제 기능 구현

## 특이 사항

- 기타 특이 사항
- Block Container에서도 InputBlock과 MethodBlock 컴포넌트를 사용하는데, setSelectedBlockId를 prop으로 전달해주지 않으면 TypeError가 발생해 전달해주었지만 현재 내부에서 사용하고있지는 않은 상태입니다.

## 주의 사항

- [x] PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요

# PR 전 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다
- [x] base 브랜치명을 확인하였습니다
- [x] 코드 컨벤션을 모두 확인하였습니다
- [x] 셀프 리뷰를 진행하였습니다.
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!
