### PR TITLE
Feat: Block Dashboard 모달 구현

### DIFF
--- a/src/components/common/InputBlock.jsx
+++ b/src/components/common/InputBlock.jsx
@@ -18,6 +18,7 @@ const InputBlock = ({
       value: inputValue,
     };
 
+    setInputValue("");
     saveBlockData(draggedBlock);
   };
 

--- a/src/components/common/Modal.jsx
+++ b/src/components/common/Modal.jsx
@@ -7,19 +7,18 @@ import {
 } from "../../style/ModalStyle";
 import { Header, ButtonContainer } from "../../style/CommonStyle";
 
-const Modal = ({ title, content }) => {
+const Modal = ({ title, content, handleCancel, handleConfirm }) => {
   return (
     <ModalBackground>
       <ModalContainer>
         <Header>
           <h2>{title}</h2>
-          <Button type="resize" text="x"></Button>
         </Header>
         <ModalContent>
           <p className="modal-content">{content}</p>
           <ButtonContainer>
-            <Button type="text" text="no" />
-            <Button type="text" text="yes" />
+            <Button type="text" text="no" handleClick={handleCancel} />
+            <Button type="text" text="yes" handleClick={handleConfirm} />
           </ButtonContainer>
         </ModalContent>
       </ModalContainer>

--- a/src/hooks/useButtonState.jsx
+++ b/src/hooks/useButtonState.jsx
@@ -11,21 +11,15 @@ const useButtonState = (lineBlocks) => {
     const hasBlock = lineBlocks.some(
       (lineBlock) => lineBlock.blocks.length > 0,
     );
-    setIsTextButtonDisabled((prevStates) => ({
-      ...prevStates,
-      reset: !hasBlock,
-    }));
-  }, [lineBlocks]);
-
-  useEffect(() => {
     const hasMethodBlock = lineBlocks.every((lineBlock) =>
       lineBlock.blocks.some((block) => block.type === "method"),
     );
-    setIsTextButtonDisabled((prevStates) => ({
-      ...prevStates,
+
+    setIsTextButtonDisabled({
+      reset: !hasBlock,
       next: !hasMethodBlock,
       create: !hasMethodBlock,
-    }));
+    });
   }, [lineBlocks]);
 
   return isTextButtonDisabled;

--- a/src/hooks/useButtonState.jsx
+++ b/src/hooks/useButtonState.jsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+
+const useButtonState = (lineBlocks) => {
+  const [isTextButtonDisabled, setIsTextButtonDisabled] = useState({
+    next: false,
+    reset: false,
+    create: false,
+  });
+
+  useEffect(() => {
+    const hasBlock = lineBlocks.some(
+      (lineBlock) => lineBlock.blocks.length > 0,
+    );
+    setIsTextButtonDisabled((prevStates) => ({
+      ...prevStates,
+      reset: !hasBlock,
+    }));
+  }, [lineBlocks]);
+
+  useEffect(() => {
+    const hasMethodBlock = lineBlocks.every((lineBlock) =>
+      lineBlock.blocks.some((block) => block.type === "method"),
+    );
+    setIsTextButtonDisabled((prevStates) => ({
+      ...prevStates,
+      next: !hasMethodBlock,
+      create: !hasMethodBlock,
+    }));
+  }, [lineBlocks]);
+
+  return isTextButtonDisabled;
+};
+
+export default useButtonState;

--- a/src/hooks/useModal.jsx
+++ b/src/hooks/useModal.jsx
@@ -1,0 +1,12 @@
+import { useState } from "react";
+
+const useModal = () => {
+  const [showModal, setShowModal] = useState(false);
+
+  const openModal = () => setShowModal(true);
+  const closeModal = () => setShowModal(false);
+
+  return [showModal, openModal, closeModal];
+};
+
+export default useModal;

--- a/src/pages/Main.jsx
+++ b/src/pages/Main.jsx
@@ -3,7 +3,6 @@ import { useState } from "react";
 import BlockContainer from "../components/BlockContainer";
 import BlockDashboard from "../components/BlockDashboard";
 import TestCodeDashboard from "../components/TestCodeDashboard";
-import Modal from "../components/common/Modal";
 
 const Main = () => {
   const [lineBlocks, setLineBlocks] = useState([
@@ -80,13 +79,13 @@ const Main = () => {
 
   return (
     <main onKeyDown={handleKeyDown} tabIndex="0">
-      <Modal title="title" content="content" />
       <BlockContainer
         handleDragStart={handleDragStart}
         setSelectedBlockId={setSelectedBlockId}
       />
       <BlockDashboard
         lineBlocks={lineBlocks}
+        setLineBlocks={setLineBlocks}
         handleDragStart={handleDragStart}
         handleDrop={handleDrop}
         handleCreateLineBlock={handleCreateLineBlock}


### PR DESCRIPTION
## 제목

Block Dashboard 내부 버튼 Modal 연동

## 내용

Block Dashboard의 reset 버튼, create 버튼을 클릭했을 때, 그에 맞는 Modal을 화면에 띄어줍니다.
<img src="https://github.com/user-attachments/assets/9cf9c717-ef22-433b-8c5d-4dee3c8f6a3a" width="400px">

## 항목

- Block Dashboard reset 버튼 클릭할 때, reset 관련 Modal 표시
- Block Dashboard create 버튼 클릭할 때, create 관련 Modal 표시
- Block Dashboard에서 재사용 가능한 로직을 Custom hook으로 관리
- Block Container에서 Block Dashboard로 Input Block을 드래그할 때, Container의 Input Field 값 초기화

## 특이 사항

- 주말 간 커스텀 훅을 조금 더 체계적으로 관리할 수 있도록 작업 진행하겠습니다. #15 

## 주의 사항

- [X] PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [X] conflict를 모두 해결하고 PR을 올려주세요

# PR 전 체크리스트

- [X] 가장 최신 브랜치를 pull 하였습니다
- [X] base 브랜치명을 확인하였습니다
- [X] 코드 컨벤션을 모두 확인하였습니다
- [X] 셀프 리뷰를 진행하였습니다.
- [X] 브랜치명을 확인하였습니다.
- [X] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!
