### PR TITLE
Feat: 개별 Block Drag 기능 구현

### DIFF
--- a/src/components/BlockContainer.jsx
+++ b/src/components/BlockContainer.jsx
@@ -9,9 +9,14 @@ import {
 } from "../style/BlockContainerStyle";
 import { Header, Section, Content } from "../style/CommonStyle";
 
-const BlockContainer = ({ handleDragStart, setSelectedBlockId }) => {
+const BlockContainer = ({
+  handleDragStart,
+  setSelectedBlockId,
+  handleDeleteBlock,
+  handleDragOver,
+}) => {
   return (
-    <Section>
+    <Section onDragOver={handleDragOver} onDrop={handleDeleteBlock}>
       <Header>
         <h2>Block Container</h2>
       </Header>

--- a/src/components/BlockDashboard.jsx
+++ b/src/components/BlockDashboard.jsx
@@ -1,5 +1,3 @@
-import { useState } from "react";
-
 import Button from "./common/Button";
 import LineBlock from "./common/LineBlock";
 import Modal from "./common/Modal";
@@ -21,36 +19,18 @@ import {
 const BlockDashboard = ({
   lineBlocks,
   setLineBlocks,
-  handleDragStart,
-  handleDrop,
+  handleBlockDragStart,
+  handleBlockDrop,
+  handleDragOver,
+  handleLineBlockDragStart,
+  handleLineBlockDrop,
   handleCreateLineBlock,
-  handleLineBlockReorder,
   setSelectedBlockId,
 }) => {
-  const [draggedLineBlockIndex, setDraggedLineBlockIndex] = useState(null);
-
   const [showResetModal, openResetModal, closeResetModal] = useModal();
   const [showCreateModal, openCreateModal, closeCreateModal] = useModal();
 
   const isTextButtonDisabled = useButtonState(lineBlocks);
-
-  const handleDragOver = (event) => {
-    event.preventDefault();
-  };
-
-  const handleLineBlockDragStart = (index) => {
-    setDraggedLineBlockIndex(index);
-  };
-
-  const handleLineBlockDrop = (dropLineBlockIndex) => {
-    if (
-      draggedLineBlockIndex !== null &&
-      draggedLineBlockIndex !== dropLineBlockIndex
-    ) {
-      handleLineBlockReorder(draggedLineBlockIndex, dropLineBlockIndex);
-    }
-    setDraggedLineBlockIndex(null);
-  };
 
   const resetBlocks = () => {
     setLineBlocks([
@@ -91,8 +71,10 @@ const BlockDashboard = ({
               key={lineBlock.id}
               index={lineBlockIndex + 1}
               blocks={lineBlock.blocks}
-              handleBlockDragStart={handleDragStart}
-              handleBlockDrop={() => handleDrop(lineBlock.id)}
+              handleBlockDragStart={(block) =>
+                handleBlockDragStart(block, lineBlockIndex)
+              }
+              handleBlockDrop={() => handleBlockDrop(lineBlockIndex)}
               handleLineBlockDragStart={() =>
                 handleLineBlockDragStart(lineBlockIndex)
               }

--- a/src/components/common/InputBlock.jsx
+++ b/src/components/common/InputBlock.jsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-
 import { InputBlockContainer } from "../../style/BlockStyle";
 
 const InputBlock = ({
@@ -11,8 +10,11 @@ const InputBlock = ({
 }) => {
   const [inputValue, setInputValue] = useState(draggedValue || "");
 
-  const handleDragStart = () => {
+  const handleDragStart = (event) => {
+    event.stopPropagation();
+
     const draggedBlock = {
+      id: inputBlockId,
       type: "input",
       parameter: parameter,
       value: inputValue,
@@ -27,8 +29,7 @@ const InputBlock = ({
   };
 
   const handleClickBlock = () => {
-    const selectedBlockId = inputBlockId;
-    setSelectedBlockId(selectedBlockId);
+    setSelectedBlockId(inputBlockId);
   };
 
   return (

--- a/src/components/common/LineBlock.jsx
+++ b/src/components/common/LineBlock.jsx
@@ -55,6 +55,11 @@ const LineBlock = ({
                   draggedValue={block.value}
                   inputBlockId={block.id}
                   setSelectedBlockId={setSelectedBlockId}
+                  draggable
+                  onDragStart={(event) => {
+                    event.stopPropagation();
+                    handleBlockDragStart(block.id, index);
+                  }}
                 />
               );
             case "method":
@@ -65,6 +70,11 @@ const LineBlock = ({
                   saveBlockData={handleBlockDragStart}
                   methodBlockId={block.id}
                   setSelectedBlockId={setSelectedBlockId}
+                  draggable
+                  onDragStart={(event) => {
+                    event.stopPropagation();
+                    handleBlockDragStart(block.id, index);
+                  }}
                 />
               );
             default:

--- a/src/components/common/MethodBlock.jsx
+++ b/src/components/common/MethodBlock.jsx
@@ -6,8 +6,11 @@ const MethodBlock = ({
   methodBlockId,
   setSelectedBlockId,
 }) => {
-  const handleDragStart = () => {
+  const handleDragStart = (event) => {
+    event.stopPropagation();
+
     const draggedBlock = {
+      id: methodBlockId,
       type: "method",
       method: method,
     };
@@ -16,8 +19,7 @@ const MethodBlock = ({
   };
 
   const handleClickBlock = () => {
-    const selectedBlockId = methodBlockId;
-    setSelectedBlockId(selectedBlockId);
+    setSelectedBlockId(methodBlockId);
   };
 
   return (

--- a/src/hooks/useBlock.jsx
+++ b/src/hooks/useBlock.jsx
@@ -1,0 +1,141 @@
+import { useState } from "react";
+
+const useDragDrop = (initialLineBlocks) => {
+  const [lineBlocks, setLineBlocks] = useState(initialLineBlocks);
+  const [draggedBlock, setDraggedBlock] = useState(null);
+  const [draggedLineIndex, setDraggedLineIndex] = useState(null);
+  const [selectedBlockId, setSelectedBlockId] = useState(null);
+
+  const hasDraggedBlock = draggedBlock !== null;
+  const hasDraggedLineIndex = draggedLineIndex !== null;
+  const hasSelectedBlockId = selectedBlockId !== null;
+
+  const handleBlockDragStart = (block, lineIndex) => {
+    setDraggedBlock(block);
+    setDraggedLineIndex(lineIndex);
+  };
+
+  const handleBlockDrop = (targetLineIndex, targetBlockId = null) => {
+    const hasTargetBlock = targetBlockId !== null;
+
+    if (hasDraggedBlock) {
+      setLineBlocks((prevLineBlocks) => {
+        return prevLineBlocks.map((lineBlock, index) => {
+          const isDraggedLine = index === draggedLineIndex;
+          const isTargetLine = index === targetLineIndex;
+
+          let newBlocks = [...lineBlock.blocks];
+
+          if (isDraggedLine) {
+            newBlocks = newBlocks.filter(
+              (block) => block.id !== draggedBlock.id,
+            );
+          }
+
+          if (isTargetLine) {
+            if (hasTargetBlock) {
+              const targetIndex = newBlocks.findIndex(
+                (block) => block.id === targetBlockId,
+              );
+
+              newBlocks.splice(targetIndex, 0, {
+                ...draggedBlock,
+                id: Date.now(),
+              });
+            } else {
+              newBlocks.push({ ...draggedBlock, id: Date.now() });
+            }
+          }
+
+          return { ...lineBlock, blocks: newBlocks };
+        });
+      });
+
+      setDraggedBlock(null);
+      setDraggedLineIndex(null);
+    }
+  };
+
+  const handleDragOver = (event) => {
+    event.preventDefault();
+  };
+
+  const handleLineBlockDragStart = (index) => {
+    setDraggedLineIndex(index);
+  };
+
+  const handleLineBlockDrop = (targetIndex) => {
+    if (hasDraggedLineIndex && draggedLineIndex !== targetIndex) {
+      setLineBlocks((prevLineBlocks) => {
+        const newLineBlocks = [...prevLineBlocks];
+        const [draggedLineBlock] = newLineBlocks.splice(draggedLineIndex, 1);
+
+        newLineBlocks.splice(targetIndex, 0, draggedLineBlock);
+
+        return newLineBlocks;
+      });
+    }
+
+    setDraggedLineIndex(null);
+  };
+
+  const handleCreateLineBlock = () => {
+    setLineBlocks((prevLineBlocks) => [
+      ...prevLineBlocks,
+      {
+        id: Date.now(),
+        blocks: [],
+      },
+    ]);
+  };
+
+  const handleDeleteBlock = () => {
+    if (hasDraggedBlock) {
+      setLineBlocks((prevLineBlocks) =>
+        prevLineBlocks.map((lineBlock) => ({
+          ...lineBlock,
+          blocks: lineBlock.blocks.filter(
+            (block) => block.id !== draggedBlock.id,
+          ),
+        })),
+      );
+
+      setDraggedBlock(null);
+      setDraggedLineIndex(null);
+    }
+  };
+
+  const handleKeyDown = (event) => {
+    if (event.key === "Delete" || event.key === "Backspace") {
+      if (hasSelectedBlockId) {
+        setLineBlocks((prevLineBlocks) =>
+          prevLineBlocks.map((lineBlock) => ({
+            ...lineBlock,
+            blocks: lineBlock.blocks.filter(
+              (block) => block.id !== selectedBlockId,
+            ),
+          })),
+        );
+
+        setSelectedBlockId(null);
+      }
+    }
+  };
+
+  return {
+    lineBlocks,
+    setLineBlocks,
+    draggedBlock,
+    handleBlockDragStart,
+    handleBlockDrop,
+    handleDragOver,
+    handleLineBlockDragStart,
+    handleLineBlockDrop,
+    handleCreateLineBlock,
+    handleDeleteBlock,
+    handleKeyDown,
+    setSelectedBlockId,
+  };
+};
+
+export default useDragDrop;

--- a/src/pages/Main.jsx
+++ b/src/pages/Main.jsx
@@ -1,97 +1,43 @@
-import { useState } from "react";
+import useBlock from "../hooks/useBlock";
 
 import BlockContainer from "../components/BlockContainer";
 import BlockDashboard from "../components/BlockDashboard";
 import TestCodeDashboard from "../components/TestCodeDashboard";
 
 const Main = () => {
-  const [lineBlocks, setLineBlocks] = useState([
-    {
-      id: Date.now(),
-      blocks: [],
-    },
-  ]);
-  const [draggedBlock, setDraggedBlock] = useState(null);
-  const [selectedBlockId, setSelectedBlockId] = useState(null);
-
-  const handleDragStart = (block) => {
-    setDraggedBlock(block);
-  };
-
-  const handleDrop = (targetBlockId) => {
-    if (draggedBlock !== null) {
-      setLineBlocks((prevLineBlocks) =>
-        prevLineBlocks.map((lineBlock) => {
-          if (lineBlock.id !== targetBlockId) {
-            return lineBlock;
-          }
-
-          return {
-            ...lineBlock,
-            blocks: [...lineBlock.blocks, { ...draggedBlock, id: Date.now() }],
-          };
-        }),
-      );
-    }
-    setDraggedBlock(null);
-  };
-
-  const handleCreateLineBlock = () => {
-    setLineBlocks((prevLineBlocks) => [
-      ...prevLineBlocks,
-      {
-        id: Date.now(),
-        blocks: [],
-      },
-    ]);
-  };
-
-  const handleLineBlockReorder = (dragIndex, dropIndex) => {
-    setLineBlocks((prevLineBlocks) => {
-      const newLineBlocks = [...prevLineBlocks];
-      const [draggedLineBlock] = newLineBlocks.splice(dragIndex, 1);
-
-      newLineBlocks.splice(dropIndex, 0, draggedLineBlock);
-
-      return newLineBlocks;
-    });
-  };
-
-  const handleDeleteBlock = () => {
-    if (selectedBlockId !== null) {
-      setLineBlocks((prevLineBlocks) =>
-        prevLineBlocks.map((lineBlock) => ({
-          ...lineBlock,
-          blocks: lineBlock.blocks.filter(
-            (block) => block.id !== selectedBlockId,
-          ),
-        })),
-      );
-      setSelectedBlockId(null);
-    }
-  };
-
-  const handleKeyDown = (event) => {
-    if (event.key === "Delete" || event.key === "Backspace") {
-      handleDeleteBlock();
-    }
-  };
-
+  const {
+    lineBlocks,
+    setLineBlocks,
+    draggedBlock,
+    handleBlockDragStart,
+    handleBlockDrop,
+    handleDragOver,
+    handleLineBlockDragStart,
+    handleLineBlockDrop,
+    handleCreateLineBlock,
+    handleDeleteBlock,
+    handleKeyDown,
+    setSelectedBlockId,
+  } = useBlock([{ id: Date.now(), blocks: [] }]);
   return (
     <main onKeyDown={handleKeyDown} tabIndex="0">
       <BlockContainer
-        handleDragStart={handleDragStart}
+        handleDragStart={handleBlockDragStart}
+        handleDragOver={handleDragOver}
+        handleDeleteBlock={handleDeleteBlock}
         setSelectedBlockId={setSelectedBlockId}
       />
       <BlockDashboard
         lineBlocks={lineBlocks}
         setLineBlocks={setLineBlocks}
-        handleDragStart={handleDragStart}
-        handleDrop={handleDrop}
+        draggedBlock={draggedBlock}
+        handleBlockDragStart={handleBlockDragStart}
+        handleBlockDrop={handleBlockDrop}
+        handleDragOver={handleDragOver}
+        handleLineBlockDragStart={handleLineBlockDragStart}
+        handleLineBlockDrop={handleLineBlockDrop}
         handleCreateLineBlock={handleCreateLineBlock}
-        handleLineBlockReorder={handleLineBlockReorder}
         setSelectedBlockId={setSelectedBlockId}
-        handleDeleteBlock={handleDeleteBlock}
       />
       <TestCodeDashboard text="Loading" />
     </main>


### PR DESCRIPTION
## 제목

개별 Block Drag 기능 구현

## 내용

프로젝트 내부 Input Block, Method Block Drag하는 경우, 삭제 및 이동 기능을 구현하였습니다.
<img src="https://github.com/user-attachments/assets/372ca36d-8d26-4c8a-9321-2c35ef152af2">


## 항목

- Block Dashboard에서 Block Container로 Drag하는 경우, Block이 삭제됩니다.
- Block Dashboard 내부 같은 Line Block에서 Drag하는 경우, Block의 순서가 바뀝니다.
- Block Dashboard 내부 다른 Line Block으로 Drag하는 경우, 다른 Line Block으로 이동합니다.
- Input Block을 Block Dashboard로 Drag하는 경우, 
  - Container의 Input Block의 값은 초기화
  - Dashboard의 Input Block의 값은 유지

## 특이 사항

- 해당 기능을 구현하기 위한 hook을 Custom Hook 파일을 생성하여 정리하였습니다.

## 주의 사항

- [x] PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요

# PR 전 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다
- [x] base 브랜치명을 확인하였습니다
- [x] 코드 컨벤션을 모두 확인하였습니다
- [x] 셀프 리뷰를 진행하였습니다.
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!
