### PR TITLE
Feat: Block Container 내 Blocks 데이터 베이스에서 렌더링

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dist-ssr
 *.local
 
 # Editor directories and files
+.env
 .vscode/*
 !.vscode/extensions.json
 .idea

--- a/src/components/BlockContainer.jsx
+++ b/src/components/BlockContainer.jsx
@@ -1,6 +1,9 @@
+import { useState, useEffect } from "react";
+
 import InputBlock from "./common/InputBlock";
 import MethodBlock from "./common/MethodBlock";
-import TextBox from "./common/TextBox";
+
+import { fetchBlocks } from "../services/blocks";
 
 import {
   BlockList,
@@ -15,6 +18,24 @@ const BlockContainer = ({
   handleDeleteBlock,
   handleDragOver,
 }) => {
+  const [inputBlocks, setInputBlocks] = useState([]);
+  const [methodBlocks, setMethodBlocks] = useState([]);
+
+  useEffect(() => {
+    const renderBlocks = async () => {
+      try {
+        const blocks = await fetchBlocks();
+
+        setInputBlocks(blocks.inputBlocks);
+        setMethodBlocks(blocks.methodBlocks);
+      } catch (error) {
+        console.error("Fetch Error");
+      }
+    };
+
+    renderBlocks();
+  }, []);
+
   return (
     <Section onDragOver={handleDragOver} onDrop={handleDeleteBlock}>
       <Header>
@@ -23,56 +44,26 @@ const BlockContainer = ({
       <Content>
         <BlockList>
           <InputBlockList>
-            <InputBlock
-              parameter="https://www.google.com"
-              saveBlockData={handleDragStart}
-              setSelectedBlockId={setSelectedBlockId}
-            />
-            <InputBlock
-              parameter="url"
-              saveBlockData={handleDragStart}
-              setSelectedBlockId={setSelectedBlockId}
-            />
-            <InputBlock
-              parameter="selector"
-              saveBlockData={handleDragStart}
-              setSelectedBlockId={setSelectedBlockId}
-            />
-            <InputBlock
-              parameter="value"
-              saveBlockData={handleDragStart}
-              setSelectedBlockId={setSelectedBlockId}
-            />
+            {inputBlocks.map((inputBlock) => (
+              <InputBlock
+                key={inputBlock._id}
+                parameter={inputBlock.parameter}
+                saveBlockData={handleDragStart}
+                setSelectedBlockId={setSelectedBlockId}
+              />
+            ))}
           </InputBlockList>
           <MethodBlockList>
-            <MethodBlock
-              method="이동합니다."
-              saveBlockData={handleDragStart}
-              setSelectedBlockId={setSelectedBlockId}
-            />
-            <MethodBlock
-              method="클릭합니다."
-              saveBlockData={handleDragStart}
-              setSelectedBlockId={setSelectedBlockId}
-            />
-            <MethodBlock
-              method="입력합니다."
-              saveBlockData={handleDragStart}
-              setSelectedBlockId={setSelectedBlockId}
-            />
-            <MethodBlock
-              method="로그인합니다."
-              saveBlockData={handleDragStart}
-              setSelectedBlockId={setSelectedBlockId}
-            />
-            <MethodBlock
-              method="오픈합니다."
-              saveBlockData={handleDragStart}
-              setSelectedBlockId={setSelectedBlockId}
-            />
+            {methodBlocks.map((methodBlock) => (
+              <MethodBlock
+                key={methodBlock._id}
+                method={methodBlock.method}
+                saveBlockData={handleDragStart}
+                setSelectedBlockId={setSelectedBlockId}
+              />
+            ))}
           </MethodBlockList>
         </BlockList>
-        <TextBox title="Text Box" />
       </Content>
     </Section>
   );

--- a/src/components/TestCodeDashboard.jsx
+++ b/src/components/TestCodeDashboard.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 
 import CodeBox from "./common/CodeBox";
 import Button from "./common/Button";
+import TextBox from "./common/TextBox";
 
 import { Section, Header, Content } from "../style/CommonStyle";
 
@@ -26,7 +27,7 @@ const TestCodeDashboard = ({ text }) => {
         <h2>Test Code Dashboard</h2>
       </Header>
       <Content>
-        <h3 className="test-code-text">Result</h3>
+        <TextBox title="Text Box" />
         <h3 className="test-code-text">{content}</h3>
         <CodeBox testCode={testCode} />
         <Button type="text" text="copy" />

--- a/src/config.jsx
+++ b/src/config.jsx
@@ -1,0 +1,5 @@
+const config = {
+  API_URL: import.meta.env.VITE_API_URL,
+};
+
+export default config;

--- a/src/services/blocks.js
+++ b/src/services/blocks.js
@@ -1,0 +1,9 @@
+import axiosInstance from "./instance";
+
+const fetchBlocks = async () => {
+  const response = await axiosInstance.get("/");
+
+  return response.data;
+};
+
+export { fetchBlocks };

--- a/src/services/instance.js
+++ b/src/services/instance.js
@@ -11,7 +11,7 @@ axiosInstance.interceptors.request.use(
   },
   (error) => {
     return Promise.reject(error);
-  }
+  },
 );
 
 export default axiosInstance;

--- a/src/services/instance.js
+++ b/src/services/instance.js
@@ -1,0 +1,17 @@
+import axios from "axios";
+import config from "../config";
+
+const axiosInstance = axios.create({
+  baseURL: config.API_URL,
+});
+
+axiosInstance.interceptors.request.use(
+  (config) => {
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  }
+);
+
+export default axiosInstance;

--- a/src/style/BlockContainerStyle.jsx
+++ b/src/style/BlockContainerStyle.jsx
@@ -2,7 +2,8 @@ import styled from "styled-components";
 
 const BlockList = styled.ul`
   display: flex;
-  gap: 0.5rem;
+  gap: 2rem;
+  margin: 4rem;
 `;
 
 const InputBlockList = styled.ul`


### PR DESCRIPTION
## 제목

Block Container 내부 Blocks 렌더링

## 내용

Block Container에 존재하는 Input Block과 Method Block을 데이터 베이스에서 불러옵니다.
<img src="https://github.com/user-attachments/assets/3ebefe4e-1165-45a9-9a2c-a8c5ae3529d5" width="200px">

사용설명서 위치 변경
<img src="https://github.com/user-attachments/assets/55aa85d4-64b1-4deb-90cc-1ba13810fab2" width="200px">

## 항목

- Axios 연결
- API에서 데이터를 불러오는 로직 (Blocks Rendering)
- Block Container에서 화면에 보여주는 로직
- 사용설명서를 Block Container에서 Test Code Container로 이동하였습니다.

## 주의 사항

- [x] PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요

# PR 전 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다
- [x] base 브랜치명을 확인하였습니다
- [x] 코드 컨벤션을 모두 확인하였습니다
- [x] 셀프 리뷰를 진행하였습니다.
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!
