### PR TITLE
Refactor: Client Edge Case

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "react-router-dom": "^6.26.0",
         "styled-components": "^6.1.12",
         "styled-reset": "^4.5.2",
+        "uuid": "^10.0.0",
         "zustand": "^4.5.5"
       },
       "devDependencies": {
@@ -5528,6 +5529,18 @@
       "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react-router-dom": "^6.26.0",
     "styled-components": "^6.1.12",
     "styled-reset": "^4.5.2",
+    "uuid": "^10.0.0",
     "zustand": "^4.5.5"
   },
   "devDependencies": {

--- a/src/components/BlockDashboard.jsx
+++ b/src/components/BlockDashboard.jsx
@@ -86,7 +86,9 @@ const BlockDashboard = () => {
               handleBlockDragStart={(block) =>
                 handleBlockDragStart(block, lineBlockIndex)
               }
-              handleBlockDrop={() => handleBlockDrop(lineBlockIndex)}
+              handleBlockDrop={(draggedBlock, targetBlock) =>
+                handleBlockDrop(lineBlockIndex, draggedBlock.id, targetBlock.id)
+              }
               handleLineBlockDragStart={() =>
                 handleLineBlockDragStart(lineBlockIndex)
               }

--- a/src/components/TestCodeDashboard.jsx
+++ b/src/components/TestCodeDashboard.jsx
@@ -48,7 +48,7 @@ const TestCodeDashboard = () => {
       <Content>
         {!isLoading && !showCodeBox && <TextBox title="Text Box" />}
         {isLoading && <h3 className="test-code-text">{content}</h3>}
-        {showCodeBox && <CodeBox testCode={testCodes} />}
+        {!isLoading && showCodeBox && <CodeBox testCode={testCodes} />}
         <Button
           type="text"
           text="copy"

--- a/src/components/common/CodeBox.jsx
+++ b/src/components/common/CodeBox.jsx
@@ -1,10 +1,14 @@
 import { CodeBoxContainer, CodeBoxContent } from "../../style/CodeBoxStyle";
 
 const CodeBox = ({ testCode }) => {
+  const startText = "const { chromium } = require('playwright'); {";
+  const endText = "await browser.close(); }";
   return (
     <CodeBoxContainer>
       <CodeBoxContent>
-        <p>{testCode}</p>
+        <pre>{startText}</pre>
+        {testCode}
+        <pre>{endText}</pre>
       </CodeBoxContent>
     </CodeBoxContainer>
   );

--- a/src/components/common/InputBlock.jsx
+++ b/src/components/common/InputBlock.jsx
@@ -45,6 +45,7 @@ const InputBlock = ({
         placeholder={parameter}
         onChange={handleInputChange}
         value={inputValue}
+        id={inputBlockId}
       />
     </InputBlockContainer>
   );

--- a/src/components/common/LineBlock.jsx
+++ b/src/components/common/LineBlock.jsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+
 import useStore from "../../store";
 
 import InputBlock from "./InputBlock";
@@ -17,7 +19,9 @@ const LineBlock = ({
   handleLineBlockDragStart,
   handleLineBlockDrop,
 }) => {
-  const { handleBlockDragOver } = useStore();
+  const { handleBlockDragOver, draggedBlock } = useStore();
+  const [targetBlock, setTargetBlock] = useState(null);
+
   const handleDragStart = (event) => {
     event.dataTransfer.setData("text/plain", "lineblock");
 
@@ -31,8 +35,12 @@ const LineBlock = ({
     if (data === "lineblock") {
       handleLineBlockDrop(index);
     } else {
-      handleBlockDrop(index);
+      handleBlockDrop(draggedBlock, targetBlock);
     }
+  };
+
+  const handleDragEnter = (event) => {
+    setTargetBlock(event.target);
   };
 
   return (
@@ -41,6 +49,7 @@ const LineBlock = ({
       onDragStart={handleDragStart}
       onDragOver={handleBlockDragOver}
       onDrop={updateDrop}
+      onDragEnter={handleDragEnter}
     >
       <BlockListContainer>
         <OrderNumber>{index}</OrderNumber>

--- a/src/components/common/MethodBlock.jsx
+++ b/src/components/common/MethodBlock.jsx
@@ -26,7 +26,9 @@ const MethodBlock = ({ method, saveBlockData, methodBlockId }) => {
       onDragStart={handleDragStart}
       onClick={handleClickBlock}
     >
-      <p className="method-block-name">{method}</p>
+      <p className="method-block-name" id={methodBlockId}>
+        {method}
+      </p>
     </MethodBlockContainer>
   );
 };

--- a/src/store/index.jsx
+++ b/src/store/index.jsx
@@ -162,6 +162,11 @@ const useSelectionStore = create((set, get) => ({
       const { lineBlocks, setLineBlocks } = useLineBlocksStore.getState();
 
       const isSelectedBlockId = selectedBlockId !== null;
+      const isTyping = ["INPUT"].includes(event.target.tagName);
+
+      if (isTyping) {
+        return;
+      }
 
       if (isSelectedBlockId) {
         const newLineBlocks = lineBlocks.map((lineBlock) => ({

--- a/src/store/index.jsx
+++ b/src/store/index.jsx
@@ -25,36 +25,78 @@ const useDragStore = create((set, get) => ({
       draggedLineIndex: lineIndex,
     }),
 
-  handleBlockDrop: (targetLineIndex, targetBlockId = null) => {
-    console.log(targetBlockId);
+  handleBlockDrop: (
+    targetLineIndex,
+    draggedBlockId = null,
+    targetBlockId = null,
+  ) => {
     const { draggedBlock, draggedLineIndex } = get();
     const { lineBlocks, setLineBlocks } = useLineBlocksStore.getState();
 
+    const isSameLine = draggedLineIndex === targetLineIndex;
+
     if (draggedBlock !== null) {
       const newLineBlocks = lineBlocks.map((lineBlock, index) => {
-        const isDraggedLine = index === draggedLineIndex;
         const isTargetLine = index === targetLineIndex;
-        let newBlocks = [...lineBlock.blocks];
+        const isDraggedLine = index === draggedLineIndex;
+        const hasDraggedBlockId = draggedBlockId !== null;
 
-        if (isDraggedLine) {
-          newBlocks = newBlocks.filter((block) => block.id !== draggedBlock.id);
-        }
+        const newBlocks = [...lineBlock.blocks];
+
+        const targetBlockIndex = newBlocks.findIndex(
+          (block) => block.id === targetBlockId,
+        );
+        const draggedBlockIndex = newBlocks.findIndex(
+          (block) => block.id === draggedBlock.id,
+        );
 
         if (isTargetLine) {
-          if (targetBlockId !== null) {
-            const targetIndex = newBlocks.findIndex(
-              (block) => block.id === targetBlockId,
-            );
-            newBlocks.splice(targetIndex, 0, {
-              ...draggedBlock,
-              id: uuidv4(),
-            });
+          if (hasDraggedBlockId) {
+            if (isSameLine) {
+              newBlocks.splice(draggedBlockIndex, 1);
+              newBlocks.splice(targetBlockIndex, 0, {
+                ...draggedBlock,
+                value: draggedBlock.value,
+              });
+            } else {
+              if (!targetBlockId) {
+                newBlocks.push({
+                  ...draggedBlock,
+                  id: draggedBlock.id || uuidv4(),
+                  value: draggedBlock.value,
+                });
+              } else {
+                newBlocks.splice(targetBlockIndex, 0, {
+                  ...draggedBlock,
+                  id: draggedBlock.id || uuidv4(),
+                  value: draggedBlock.value,
+                });
+              }
+            }
           } else {
-            newBlocks.push({ ...draggedBlock, id: uuidv4() });
+            if (!targetBlockId) {
+              newBlocks.push({
+                ...draggedBlock,
+                id: draggedBlock.id || uuidv4(),
+                value: draggedBlock.value,
+              });
+            } else {
+              newBlocks.splice(targetBlockIndex, 0, {
+                ...draggedBlock,
+                id: draggedBlock.id || uuidv4(),
+                value: draggedBlock.value,
+              });
+            }
           }
         }
 
-        return { ...lineBlock, blocks: newBlocks };
+        return {
+          ...lineBlock,
+          blocks:
+            isDraggedLine && !isSameLine
+              ? newBlocks.filter((block) => block.id !== draggedBlock.id)
+              : newBlocks,
+        };
       });
 
       setLineBlocks(newLineBlocks);
@@ -75,7 +117,10 @@ const useDragStore = create((set, get) => ({
     const { draggedLineIndex } = get();
     const { lineBlocks, setLineBlocks } = useLineBlocksStore.getState();
 
-    if (draggedLineIndex !== null && draggedLineIndex !== targetIndex) {
+    const isOtherLine =
+      draggedLineIndex !== null && draggedLineIndex !== targetIndex;
+
+    if (isOtherLine) {
       const newLineBlocks = [...lineBlocks];
       const [draggedLineBlock] = newLineBlocks.splice(draggedLineIndex, 1);
 
@@ -95,7 +140,9 @@ const useSelectionStore = create((set, get) => ({
     const { draggedBlock } = useDragStore.getState();
     const { lineBlocks, setLineBlocks } = useLineBlocksStore.getState();
 
-    if (draggedBlock !== null) {
+    const isDraggedBlock = draggedBlock !== null;
+
+    if (isDraggedBlock) {
       const newLineBlocks = lineBlocks.map((lineBlock) => ({
         ...lineBlock,
         blocks: lineBlock.blocks.filter(
@@ -114,7 +161,9 @@ const useSelectionStore = create((set, get) => ({
       const { selectedBlockId } = get();
       const { lineBlocks, setLineBlocks } = useLineBlocksStore.getState();
 
-      if (selectedBlockId !== null) {
+      const isSelectedBlockId = selectedBlockId !== null;
+
+      if (isSelectedBlockId) {
         const newLineBlocks = lineBlocks.map((lineBlock) => ({
           ...lineBlock,
           blocks: lineBlock.blocks.filter(

--- a/src/store/index.jsx
+++ b/src/store/index.jsx
@@ -1,17 +1,18 @@
 import { create } from "zustand";
+import { v4 as uuidv4 } from "uuid";
 
 const useLineBlocksStore = create((set) => ({
-  lineBlocks: [{ id: Date.now(), blocks: [] }],
+  lineBlocks: [{ id: uuidv4(), blocks: [] }],
 
   setLineBlocks: (lineBlocks) => set({ lineBlocks }),
 
   handleCreateLineBlock: () =>
     set((state) => ({
-      lineBlocks: [...state.lineBlocks, { id: Date.now(), blocks: [] }],
+      lineBlocks: [...state.lineBlocks, { id: uuidv4(), blocks: [] }],
     })),
 
   handleResetLineBlocks: () =>
-    set({ lineBlocks: [{ id: Date.now(), blocks: [] }] }),
+    set({ lineBlocks: [{ id: uuidv4(), blocks: [] }] }),
 }));
 
 const useDragStore = create((set, get) => ({
@@ -25,6 +26,7 @@ const useDragStore = create((set, get) => ({
     }),
 
   handleBlockDrop: (targetLineIndex, targetBlockId = null) => {
+    console.log(targetBlockId);
     const { draggedBlock, draggedLineIndex } = get();
     const { lineBlocks, setLineBlocks } = useLineBlocksStore.getState();
 
@@ -45,10 +47,10 @@ const useDragStore = create((set, get) => ({
             );
             newBlocks.splice(targetIndex, 0, {
               ...draggedBlock,
-              id: Date.now(),
+              id: uuidv4(),
             });
           } else {
-            newBlocks.push({ ...draggedBlock, id: Date.now() });
+            newBlocks.push({ ...draggedBlock, id: uuidv4() });
           }
         }
 

--- a/src/style/BlockStyle.jsx
+++ b/src/style/BlockStyle.jsx
@@ -11,8 +11,9 @@ const MethodBlockContainer = styled.li`
     display: flex;
     justify-content: center;
     align-items: center;
-    padding: 1rem 0;
+    padding: 1rem 0.5rem;
     height: 2rem;
+    font-size: ${({ theme }) => theme.fontSize.xxsmall};
     background: ${({ theme }) => theme.color.barColor};
     color: ${({ theme }) => theme.color.whiteColor};
     border: 0.15rem solid ${({ theme }) => theme.color.blackColor};

--- a/src/style/CodeBoxStyle.jsx
+++ b/src/style/CodeBoxStyle.jsx
@@ -3,13 +3,13 @@ import styled from "styled-components";
 const CodeBoxContainer = styled.div`
   display: flex;
   justify-content: center;
+  width: 80%;
 `;
 
 const CodeBoxContent = styled.div`
   display: flex;
   flex-direction: column;
   padding: 1rem;
-  width: 80%;
   height: 20rem;
   background-color: ${({ theme }) => theme.color.whiteColor};
   border: 0.1rem solid ${({ theme }) => theme.color.blackColor};
@@ -17,6 +17,7 @@ const CodeBoxContent = styled.div`
   overflow: scroll;
   overflow-x: auto;
   gap: 1rem;
+  white-space: pre-wrap;
 
   p {
     background-color: inherit;


### PR DESCRIPTION
## 제목

클라이언트 코드 리팩토링

## 내용

Drag & Drop Edge Case를 해결하고 Test Code Dashboard를 개선하였습니다.

| Drag & Drop | Test Code Dashboard |
|-|-|
| <img src="https://github.com/user-attachments/assets/ec196e4b-cfd2-40bb-9d57-d09a36126715" width="230px"> | <img src="https://github.com/user-attachments/assets/4de8c5bf-3b66-4f94-8270-eecd02e35fdf" width="450px"> |


## 항목
- 블록 ID 값 부여 (`Date.now()` vs **UUID**)
  우리는 밀리초 단위로 난수를 생성하기 위해 간혹 `Date.now()`를 사용하지만 이 숫자는 항상 고유성을 보장하지는 않습니다. 
  > 컴퓨터는 밀리초 이내에도 몇 번의 루프를 반복하여 실행할 수 있습니다. 
  > 만약 여러 요소를 순회하는 반복문 안에서 각 요소에 id 값을 `Date.now()`로 부여할 경우, 
  > 같은 밀리초에 id값이 부여된 요소들은 같은 난수를 사용하는 <ins>위험한 상황</ins>이 발생할 수 있습니다.
  
  [참고자료](https://dev.to/rahmanfadhil/how-to-generate-unique-id-in-javascript-1b13)

- Drag & Drop Edge Case
  - 같은 라인 블록에서 개별 블록의 순서 이동
  - 다른 라인 블록으로 개별 블록의 순서 이동
  - 원하는 위치에 개별 블록 이동
 
- Test Code Dashboard
  - Test Code 생성할 때까지 Loading 화면 구현 (조건부 렌더링)
 
- 키보드로 블록을 제거하는 경우, 
  - Input Field를 수정할 때, 블록이 (의도와 다르게) 지워지는 상황 해결

## 특이 사항
- 추후 구현해야할 사항 8/23(금)

  - 블록이 이동하는 예상 위치를 표시 #24 
  - Test Code 전체 코드 복사 기능 #25

## 주의 사항

- [x] PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요

# PR 전 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다
- [x] base 브랜치명을 확인하였습니다
- [x] 코드 컨벤션을 모두 확인하였습니다
- [x] 셀프 리뷰를 진행하였습니다.
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!
