### PR TITLE
Feat: Block이 떨어질 위치를 표시

### DIFF
--- a/src/components/common/InputBlock.jsx
+++ b/src/components/common/InputBlock.jsx
@@ -40,12 +40,12 @@ const InputBlock = ({
       draggable="true"
       onDragStart={handleDragStart}
       onClick={handleClickBlock}
+      id={inputBlockId}
     >
       <input
         placeholder={parameter}
         onChange={handleInputChange}
         value={inputValue}
-        id={inputBlockId}
       />
     </InputBlockContainer>
   );

--- a/src/components/common/LineBlock.jsx
+++ b/src/components/common/LineBlock.jsx
@@ -49,16 +49,16 @@ const LineBlock = ({
       event.target.tagName !== "INPUT";
 
     if (hasDroppedPosition) {
-      event.target.classList.add("dropped-position");
+      event.target.classList.add("border");
     }
 
     if (targetBlock) {
-      targetBlock.classList.remove("dropped-position");
+      targetBlock.classList.remove("border");
     }
   };
 
   const handleDragEnd = (event) => {
-    event.target.classList.remove("dropped-position");
+    event.target.classList.remove("border");
   };
 
   return (

--- a/src/components/common/LineBlock.jsx
+++ b/src/components/common/LineBlock.jsx
@@ -36,11 +36,29 @@ const LineBlock = ({
       handleLineBlockDrop(index);
     } else {
       handleBlockDrop(draggedBlock, targetBlock);
+      targetBlock.classList.remove("border");
     }
   };
 
   const handleDragEnter = (event) => {
     setTargetBlock(event.target);
+
+    const hasDroppedPosition =
+      event.target &&
+      event.target !== targetBlock &&
+      event.target.tagName !== "INPUT";
+
+    if (hasDroppedPosition) {
+      event.target.classList.add("dropped-position");
+    }
+
+    if (targetBlock) {
+      targetBlock.classList.remove("dropped-position");
+    }
+  };
+
+  const handleDragEnd = (event) => {
+    event.target.classList.remove("dropped-position");
   };
 
   return (
@@ -50,6 +68,7 @@ const LineBlock = ({
       onDragOver={handleBlockDragOver}
       onDrop={updateDrop}
       onDragEnter={handleDragEnter}
+      onDragEnd={handleDragEnd}
     >
       <BlockListContainer>
         <OrderNumber>{index}</OrderNumber>

--- a/src/style/BlockStyle.jsx
+++ b/src/style/BlockStyle.jsx
@@ -54,7 +54,7 @@ const LineBlockContainer = styled.li`
   border-right: 0.15rem solid ${({ theme }) => theme.color.blackColor};
   border-bottom: 0.15rem solid ${({ theme }) => theme.color.blackColor};
 
-  .dropped-position {
+  .border {
     opacity: 50%;
     border: 5px solid blue;
   }

--- a/src/style/BlockStyle.jsx
+++ b/src/style/BlockStyle.jsx
@@ -13,11 +13,13 @@ const MethodBlockContainer = styled.li`
     align-items: center;
     padding: 1rem 0.5rem;
     height: 2rem;
+    width: 6rem;
     font-size: ${({ theme }) => theme.fontSize.xxsmall};
     background: ${({ theme }) => theme.color.barColor};
     color: ${({ theme }) => theme.color.whiteColor};
     border: 0.15rem solid ${({ theme }) => theme.color.blackColor};
   }
+
   .method-block-name:active {
     border-color: ${({ theme }) => theme.color.redColor};
   }
@@ -28,6 +30,7 @@ const InputBlockContainer = styled.li`
   justify-content: center;
   align-items: center;
   height: 2rem;
+  width: 8rem;
   padding: 1rem 0.8rem;
   background: ${({ theme }) => theme.color.grayColor};
   color: ${({ theme }) => theme.color.whiteColor};
@@ -50,6 +53,11 @@ const LineBlockContainer = styled.li`
   border-left: 0.1rem solid ${({ theme }) => theme.color.whiteColor};
   border-right: 0.15rem solid ${({ theme }) => theme.color.blackColor};
   border-bottom: 0.15rem solid ${({ theme }) => theme.color.blackColor};
+
+  .dropped-position {
+    opacity: 50%;
+    border: 5px solid blue;
+  }
 `;
 
 const OrderNumber = styled.div`

--- a/src/style/GlobalStyle.jsx
+++ b/src/style/GlobalStyle.jsx
@@ -36,6 +36,7 @@ const GlobalStyle = createGlobalStyle`
 
   input {
     padding: 0.2rem;
+    width: 7rem;
     border: 0.2rem solid ${({ theme }) => theme.color.blackColor};
     background-color: ${({ theme }) => theme.color.whiteColor};
   }


### PR DESCRIPTION
## 제목

Block이 떨어질 위치를 표시 #24 

## 내용

Drop할 블록의 위치를 투명도와 Border로 사용자에게 안내합니다.

https://github.com/user-attachments/assets/5f2cd31d-bcde-42e0-af80-ccc3cd2cde2c


## 항목

- 떨어질 위치의 블록에 파란 테두리와 연한 투명도를 적용

## 주의 사항

- [x] PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요

# PR 전 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다
- [x] base 브랜치명을 확인하였습니다
- [x] 코드 컨벤션을 모두 확인하였습니다
- [x] 셀프 리뷰를 진행하였습니다.
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!
